### PR TITLE
fix(ci): remove double (deps) scope from dependabot commit prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       - dependencies
       - java
     commit-message:
-      prefix: chore(deps)
+      prefix: chore
       include: scope
 
   - package-ecosystem: docker
@@ -27,7 +27,7 @@ updates:
       - dependencies
       - docker
     commit-message:
-      prefix: chore(deps)
+      prefix: chore
       include: scope
 
   - package-ecosystem: github-actions
@@ -42,5 +42,5 @@ updates:
       - dependencies
       - github-actions
     commit-message:
-      prefix: chore(deps)
+      prefix: chore
       include: scope


### PR DESCRIPTION
## Summary

Fixes the Dependabot commit-message format. Current Dependabot PRs produce titles like `chore(deps)(deps): bump ...` (double `(deps)`), which is ugly and visible in existing open PRs.

Root cause: `dependabot.yml` set `prefix: chore(deps)` **and** `include: scope`, so Dependabot appends its own scope on top of the hard-coded one.

Fix: change `prefix: chore` → `include: scope` then produces `chore(deps): bump ...` as expected.

## Type of change

- [x] `fix` — bug fix (patch bump)

## Checklist

- [x] PR title follows Conventional Commits
- [x] No breaking change
- [x] `mvn test` not affected (CI config only)

## How to test

After merge, wait for Dependabot to refresh / close and reopen its PRs — the new commit messages will read `chore(deps): bump X to Y`.

Existing open Dependabot PRs already on the repo can be closed and recreated, or they can be rebased; Dependabot will re-title them on the next run.