### PR TITLE
fix(security): restore test suite and return 401 for unauthenticated REST calls

### DIFF
--- a/src/main/java/com/bookstore/security/SecurityConfig.java
+++ b/src/main/java/com/bookstore/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.bookstore.security;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -11,6 +12,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
@@ -47,6 +49,8 @@ public class SecurityConfig {
                 )
                 .headers(headers -> headers
                         .frameOptions(frame -> frame.disable()))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/test/java/com/bookstore/controller/AuthControllerTest.java
+++ b/src/test/java/com/bookstore/controller/AuthControllerTest.java
@@ -4,12 +4,16 @@ import com.bookstore.model.Role;
 import com.bookstore.model.User;
 import com.bookstore.repository.UserRepository;
 import com.bookstore.security.CustomUserDetailsService;
+import com.bookstore.security.JwtAuthFilter;
 import com.bookstore.security.JwtUtil;
+import com.bookstore.security.SecurityConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -31,7 +35,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(AuthController.class)
+@WebMvcTest(
+        controllers = AuthController.class,
+        excludeAutoConfiguration = UserDetailsServiceAutoConfiguration.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
 @DisplayName("AuthController")
 class AuthControllerTest {
 

--- a/src/test/java/com/bookstore/controller/AuthorControllerTest.java
+++ b/src/test/java/com/bookstore/controller/AuthorControllerTest.java
@@ -2,16 +2,21 @@ package com.bookstore.controller;
 
 import com.bookstore.dto.AuthorResponse;
 import com.bookstore.security.CustomUserDetailsService;
+import com.bookstore.security.JwtAuthFilter;
 import com.bookstore.security.JwtUtil;
+import com.bookstore.security.SecurityConfig;
 import com.bookstore.service.AuthorService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.server.ResponseStatusException;
@@ -25,7 +30,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(AuthorController.class)
+@WebMvcTest(
+        controllers = AuthorController.class,
+        excludeAutoConfiguration = UserDetailsServiceAutoConfiguration.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
 @DisplayName("AuthorController")
 class AuthorControllerTest {
 
@@ -113,6 +121,7 @@ class AuthorControllerTest {
         }
 
         @Test
+        @WithAnonymousUser
         @DisplayName("returns 401 when not authenticated")
         void returns401WhenNotAuthenticated() throws Exception {
             mockMvc.perform(post("/api/authors")

--- a/src/test/java/com/bookstore/controller/BookControllerTest.java
+++ b/src/test/java/com/bookstore/controller/BookControllerTest.java
@@ -2,16 +2,21 @@ package com.bookstore.controller;
 
 import com.bookstore.dto.BookResponse;
 import com.bookstore.security.CustomUserDetailsService;
+import com.bookstore.security.JwtAuthFilter;
 import com.bookstore.security.JwtUtil;
+import com.bookstore.security.SecurityConfig;
 import com.bookstore.service.BookService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.server.ResponseStatusException;
@@ -32,7 +37,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(BookController.class)
+@WebMvcTest(
+        controllers = BookController.class,
+        excludeAutoConfiguration = UserDetailsServiceAutoConfiguration.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
 @DisplayName("BookController")
 class BookControllerTest {
 
@@ -127,6 +135,7 @@ class BookControllerTest {
         }
 
         @Test
+        @WithAnonymousUser
         @DisplayName("returns 401 when not authenticated")
         void returns401WhenNotAuthenticated() throws Exception {
             mockMvc.perform(post("/api/books")
@@ -205,6 +214,7 @@ class BookControllerTest {
         }
 
         @Test
+        @WithAnonymousUser
         @DisplayName("returns 401 when not authenticated")
         void returns401WhenNotAuthenticated() throws Exception {
             mockMvc.perform(put("/api/books/1")
@@ -250,6 +260,7 @@ class BookControllerTest {
         }
 
         @Test
+        @WithAnonymousUser
         @DisplayName("returns 401 when not authenticated")
         void returns401WhenNotAuthenticated() throws Exception {
             mockMvc.perform(delete("/api/books/1"))


### PR DESCRIPTION
## Summary

The bookstore example had three latent issues surfaced by the first CI run. All three are fixed here; `mvn test` now passes locally (64/64).

### 1. `@WebMvcTest` slices couldn't load `ApplicationContext`

Root cause: Spring Security's `UserDetailsServiceAutoConfiguration` registers an `inMemoryUserDetailsManager` that collides with the app's own `CustomUserDetailsService` bean. `AuthController` has a single `UserDetailsService` constructor parameter, so Spring fails with "expected single matching bean but found 2".

Fix: on each controller test, `excludeAutoConfiguration = UserDetailsServiceAutoConfiguration.class` and `@Import({SecurityConfig.class, JwtAuthFilter.class})` so the real security rules are active in tests.

### 2. Unauthenticated REST calls returned `403` instead of `401`

`SecurityConfig` had no `AuthenticationEntryPoint`, so Spring Security's default `AccessDeniedHandler` answered unauthenticated calls with 403. The existing test `returns403ForNonAdmin` shows the author clearly distinguished the two statuses — 401 for "please authenticate", 403 for "authenticated but wrong role".

Fix: `.exceptionHandling(ex -> ex.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))` in `SecurityConfig`.

### 3. `SecurityContext` bleed between nested `@Test` methods

In `BookControllerTest$DeleteBook`, `returns403ForNonAdmin` uses `@WithMockUser(roles = "USER")`, and the subsequent `returns401WhenNotAuthenticated` was seeing the USER authentication left behind, producing 403.

Fix: `@WithAnonymousUser` on the four `returns401WhenNotAuthenticated` tests to explicitly clear the context.

## Type of change

- [x] `fix` — bug fix (patch bump)

## Checklist

- [x] PR title follows Conventional Commits
- [x] `mvn test` passes locally (64/64)
- [x] No breaking change — public REST semantics moved from non-standard 403 to RFC-correct 401 for unauthenticated requests, which is what the tests already expected
- [x] Docs unchanged (behaviour was silently broken; no doc describes the previous 403 behaviour)

## How to test

```bash
mvn test
```

After merge, the CI workflow on `main` and `develop` will go green, and the build-and-push pipeline will start generating stable releases.