### PR TITLE
fix(ci): grant contents:write to semantic-version job

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -16,7 +16,7 @@ jobs:
     name: Determine Version
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     outputs:
       version: ${{ steps.semver.outputs.version }}
       new_release_published: ${{ steps.semver.outputs.new_release_published }}


### PR DESCRIPTION
## Summary

Releases weren't being cut even when `fix:` / `feat:` commits landed on `main`, because the semantic-release dry-run was silently failing under the job's read-only token.

Root cause: `semantic-release --dry-run` internally runs `git push --dry-run` to validate push permissions (it verifies it **could** push before proceeding). With `permissions: contents: read`, that inner check returns 403, semantic-release exits early, no "The next release version is X" line appears, and our grep-based extractor falls back to "no release needed".

After this change:
- `semantic-version` job has `contents: write` (matches the d4c-portal reference)
- `build-and-push` stays at `contents: read, packages: write`
- `create-release` stays at `contents: write, issues: write, pull-requests: write`

## Type of change

- [x] `fix` — bug fix (patch bump)

## Checklist

- [x] PR title follows Conventional Commits
- [x] No behavior change in app code — CI-config-only fix
- [x] After merge, the release job should fire and publish **v1.0.1** with all the accumulated `fix:` commits in the CHANGELOG

## How to test

After merge, watch the `Build and Push to GHCR` run on `main`:
- Dry-run step should log `New version detected: 1.0.1`
- `create-release` job should run and publish a GitHub Release + the `v1.0.1` tag
- `ghcr.io/automatica-cluj/isp-bookstore-2026-complete:v1.0.1` should become pullable
- `CHANGELOG.md` and `pom.xml` should be updated on `main` via the `chore(release): 1.0.1 [skip ci]` commit