### PR TITLE
fix(ci): match semantic-release version line regardless of case

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -53,7 +53,7 @@ jobs:
           cat /tmp/semver-output.txt
           echo "======================================="
 
-          NEXT_VERSION=$(grep -oP "The next release version is \K[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?" /tmp/semver-output.txt | head -1 || echo "")
+          NEXT_VERSION=$(grep -oiP "the next release version is \K[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?" /tmp/semver-output.txt | head -1 || echo "")
 
           if [ -z "$NEXT_VERSION" ]; then
             LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")


### PR DESCRIPTION
## Summary

This is the **real** reason no release has been cut yet. PR #14 fixed the permissions so semantic-release could run in full, and the dry-run log now shows:

```
[semantic-release] › ℹ  There is no previous release, the next release version is 1.0.0
[semantic-release] › ✔  Published release 1.0.0 on default channel
```

But our grep pattern `The next release version is ...` (capital `T`) didn't match the `the next release version is ...` (lowercase `t`) form semantic-release emits on the **very first** release when there's no prior tag. So the extractor returned empty, we fell back to "no release", and `create-release` was skipped.

Fix: add the `-i` flag to grep so both forms match.

```diff
- NEXT_VERSION=$(grep -oP "The next release version is \K[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?" ...
+ NEXT_VERSION=$(grep -oiP "the next release version is \K[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?" ...
```

## Type of change

- [x] `fix` — bug fix (patch bump)

## Checklist

- [x] PR title follows Conventional Commits
- [x] One-character CI-config change

## How to test

After merge, run `build-push.yml` manually on main from the Actions tab (or wait for the next push). The dry-run step should log `New version detected: 1.0.0`, the `create-release` job should run, and a GitHub Release + `v1.0.0` tag should appear.

After that, future `fix:`/`feat:` commits will trigger `v1.0.1`, `v1.1.0`, etc. as expected.