### PR TITLE
chore(ci): align release rules with promotion convention

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -219,29 +219,38 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Merge main into develop (main wins on pom.xml / CHANGELOG.md)
+      - name: Squash-merge main into develop
         run: |
           set -e
           git fetch origin main
 
-          if git merge origin/main --no-ff \
-               -m "chore(sync): back-merge main v${{ needs.semantic-version.outputs.version }} into develop"; then
-            echo "Clean merge."
-          else
-            # Only auto-resolve the two release-managed files. Any other conflict aborts.
+          # Squash-merge collapses main's new commits (including the
+          # `chore(release)` commit that holds a release-triggering scope)
+          # into a single `chore(sync)` commit on develop. That keeps
+          # semantic-release on develop from re-analyzing main's release
+          # commit and cutting a phantom prerelease.
+          if ! git merge --squash origin/main; then
+            # Auto-resolve only the two release-managed files; abort on
+            # any real code conflict so a maintainer sees it.
             git checkout origin/main -- pom.xml CHANGELOG.md
             git add pom.xml CHANGELOG.md
 
             if git ls-files -u | grep .; then
               echo "::error::Non-release conflicts detected; aborting back-merge for manual resolution."
-              git merge --abort
+              git merge --abort || true
+              git reset --hard HEAD
               exit 1
             fi
-
-            git commit --no-edit
           fi
 
-          git push origin develop
+          # `git merge --squash` stages changes but doesn't commit.
+          # Only commit if there's actually something to record.
+          if git diff --cached --quiet; then
+            echo "Nothing to back-merge (develop already contains main)."
+          else
+            git commit -m "chore(sync): back-merge main v${{ needs.semantic-version.outputs.version }} into develop"
+            git push origin develop
+          fi
 
       - name: Back-merge summary
         run: |

--- a/release.config.js
+++ b/release.config.js
@@ -28,6 +28,13 @@ module.exports = {
       {
         preset: 'conventionalcommits',
         releaseRules: [
+          // Promotion PRs (develop → main) are titled `chore(release): ...`
+          // or `chore(promote): ...`. They arrive on main as a single
+          // squash-merged chore commit, so the scope — not the type — is
+          // what has to trigger the release.
+          { type: 'chore', scope: 'sync', release: false },
+          { type: 'chore', scope: 'release', release: 'minor' },
+          { type: 'chore', scope: 'promote', release: 'minor' },
           { type: 'feat', release: 'minor' },
           { type: 'fix', release: 'patch' },
           { type: 'perf', release: 'patch' },


### PR DESCRIPTION
## Summary

Two interlocking fixes so the squash-merge-only flow actually cuts releases end-to-end.

### The problem

- Our repo is squash-merge only, so `develop → main` produces **one** commit on `main` whose message = the PR title.
- The `pr-title.yml` guard we added requires that title to be `chore(release|promote|sync): ...`.
- But `release.config.js` has `chore = no release` — so a correctly-titled promotion PR produces zero releases. Broken.

On top of that, the current `sync-develop` back-merge uses a normal `git merge`, which drags main's `chore(release)` commit onto `develop`. On the next `semantic-release` run on develop, that commit would re-match a release rule and cut a phantom `vX.Y.Z-beta.N+1`.

### The fix (two files)

**`release.config.js`** — prepend scope-based rules so the promotion title itself is the release trigger:

```js
{ type: 'chore', scope: 'sync',    release: false },
{ type: 'chore', scope: 'release', release: 'minor' },
{ type: 'chore', scope: 'promote', release: 'minor' },
```

These sit above the existing `{ type: 'chore', release: false }` rule so the scope matches first. `chore(sync)` still means no release.

**`build-push.yml` → `sync-develop` job** — change `git merge` to `git merge --squash`. The back-merge produces a single `chore(sync): back-merge main vX.Y.Z into develop` commit on develop. semantic-release sees only that commit (not main's release commit), matches `scope: sync → false`, and cuts no prerelease.

### What works after this lands

1. Feature PR → `develop`, squash-merged → `semantic-release` cuts `vX.Y.Z-beta.N`.
2. Promotion PR → `main`, titled `chore(release): vX.Y.Z`, squash-merged → `semantic-release` cuts stable `vX.Y.Z`.
3. `sync-develop` auto back-merges with `--squash` → develop stays aligned, no phantom beta.

## Test plan

- [ ] `mvn test` green (no application code touched)
- [ ] After merge: open the promotion PR `develop → main` titled `chore(release): v1.6.0` and confirm a stable `v1.6.0` is cut, then `sync-develop` runs and develop ends up with a single `chore(sync)` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)