### PR TITLE
feat: add tagCount to statistics endpoint

### DIFF
--- a/src/main/java/com/bookstore/controller/StatisticsController.java
+++ b/src/main/java/com/bookstore/controller/StatisticsController.java
@@ -20,13 +20,14 @@ public class StatisticsController {
     }
 
     /**
-     * Count  books!!!!!
-     * @return
+     * Aggregate catalogue statistics: total number of books and the number of
+     * distinct tags across all books (deduplicated via {@code HashSet}).
      */
     @GetMapping
     public ResponseEntity<Map<String, Object>> getStatistics() {
         Map<String, Object> stats = new HashMap<>();
         stats.put("bookCount", bookService.countAll());
+        stats.put("tagCount", bookService.getAllTags().size());
         return ResponseEntity.ok(stats);
     }
 

--- a/src/test/java/com/bookstore/controller/StatisticsControllerTest.java
+++ b/src/test/java/com/bookstore/controller/StatisticsControllerTest.java
@@ -1,0 +1,73 @@
+package com.bookstore.controller;
+
+import com.bookstore.repository.UserRepository;
+import com.bookstore.security.CustomUserDetailsService;
+import com.bookstore.security.JwtAuthFilter;
+import com.bookstore.security.JwtUtil;
+import com.bookstore.security.SecurityConfig;
+import com.bookstore.service.BookService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Set;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = StatisticsController.class,
+        excludeAutoConfiguration = UserDetailsServiceAutoConfiguration.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
+@DisplayName("StatisticsController")
+class StatisticsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private BookService bookService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @Nested
+    @DisplayName("GET /api/statistics")
+    class GetStatistics {
+
+        @Test
+        @WithMockUser
+        @DisplayName("returns 200 with bookCount and tagCount for an authenticated user")
+        void returnsBookAndTagCount() throws Exception {
+            when(bookService.countAll()).thenReturn(3);
+            when(bookService.getAllTags()).thenReturn(Set.of("java", "spring", "testing"));
+
+            mockMvc.perform(get("/api/statistics"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.bookCount").value(3))
+                    .andExpect(jsonPath("$.tagCount").value(3));
+        }
+
+        @Test
+        @DisplayName("returns 401 for an unauthenticated request")
+        void returns401WhenUnauthenticated() throws Exception {
+            mockMvc.perform(get("/api/statistics"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `tagCount` field to `GET /api/statistics` — the number of distinct tags across all books, deduplicated via the existing `HashSet`-based `BookService.getAllTags()` (fits the course's Collections teaching lens).

This is also the first `feat:` to exercise the **new single-branch release pipeline** end-to-end — merging it should cut `v1.6.0`.

## Type of change
- [x] `feat` — new user-visible behaviour (minor bump)

## How to test
`GET /api/statistics` (authenticated) now returns `{ "bookCount": N, "tagCount": M }`.
Covered by `StatisticsControllerTest` (authenticated 200 + unauthenticated 401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)