### PR TITLE
ci: ignore major version bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    # Skip major bumps (e.g. Spring Boot 3.x → 4.x) — they need a deliberate,
+    # reviewed upgrade, not an auto-PR. Minor/patch (incl. security) still flow.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: docker
     directory: /
@@ -29,6 +34,10 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    # Skip major base-image bumps — review those by hand.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /
@@ -44,3 +53,7 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    # Skip major action bumps (e.g. actions/setup-java v4 → v5) — review by hand.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Adds `ignore` rules for `version-update:semver-major` to all three ecosystems (maven, docker, github-actions). Stops Dependabot re-opening the major bumps that were declined (Spring Boot 3→4, setup-java v4→v5, metadata-action v5→v6, upload-artifact v4→v7); minor/patch (incl. security) PRs still flow. No release (ci).