### PR TITLE
fix(docker): publish multi-arch image (amd64 + arm64)

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -74,6 +74,11 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Image version: $VERSION (released: ${{ steps.semrel.outputs.new_release_published }})"
 
+      # Build the JAR natively on the runner (fast, no emulation). The artifact
+      # is architecture-independent, so the multi-arch image below just copies it.
+      - name: Build application JAR
+        run: mvn -B clean package -DskipTests
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -99,8 +104,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
+          file: ./Dockerfile.runtime
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,0 +1,28 @@
+# Runtime-only image used by CI to publish a fast multi-arch (amd64 + arm64) image.
+#
+# It copies a JAR that CI already built natively on the runner. A Spring Boot JAR
+# is Java bytecode and therefore architecture-independent, so the same artifact
+# works on every platform — and because this Dockerfile has no RUN step, buildx
+# can assemble both architectures without QEMU emulation (just pulls the per-arch
+# JRE base and adds the copy layer).
+#
+# For LOCAL development use the self-contained `Dockerfile` instead (it builds the
+# JAR in-image); `compose.dev.yml` already points at it.
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+
+ARG VERSION=dev
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+
+LABEL org.opencontainers.image.title="ISP 2026 Bookstore"
+LABEL org.opencontainers.image.description="Spring Boot bookstore API for the ISP 2026 course"
+LABEL org.opencontainers.image.source="https://github.com/automatica-cluj/isp-bookstore-2026-complete"
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.revision="${VCS_REF}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.licenses="MIT"
+
+COPY target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then open <http://localhost:8090>.
 
 ## Run with a published image (production-like)
 
-Images are published to GHCR on every push to `main`:
+Images are published to GHCR on every push to `main` as **multi-arch** (`linux/amd64` + `linux/arm64`), so they pull natively on both Intel and Apple Silicon:
 
 - `ghcr.io/automatica-cluj/isp-bookstore-2026-complete:latest` — most recent `main`
 - `ghcr.io/automatica-cluj/isp-bookstore-2026-complete:v1.2.3` — released version tag


### PR DESCRIPTION
## Summary

Fixes `no matching manifest for linux/arm64/v8` when pulling the image on Apple Silicon — the published image was `linux/amd64` only.

- Builds the (architecture-independent) JAR natively on the runner, then assembles a multi-arch image (`amd64` + `arm64`) from a new copy-only `Dockerfile.runtime`. No `RUN` step → buildx needs no QEMU emulation, so CI stays fast (~3-4 min).
- The self-contained `Dockerfile` is unchanged and still used by `compose.dev.yml` for local builds.
- README notes images are now multi-arch.

Merging cuts `v1.6.1` (patch) and republishes `latest` as multi-arch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)