### PR TITLE
fix(docker): include prebuilt JAR in runtime build context

### DIFF
--- a/Dockerfile.runtime.dockerignore
+++ b/Dockerfile.runtime.dockerignore
@@ -1,0 +1,6 @@
+# Build context for Dockerfile.runtime — it only needs the prebuilt JAR.
+# (The default .dockerignore excludes target/, which is correct for the
+# self-contained Dockerfile but would hide the JAR from this runtime build.
+# BuildKit uses this <dockerfile>.dockerignore in preference to .dockerignore.)
+*
+!target


### PR DESCRIPTION
## Summary

Follow-up to #47. The multi-arch publish failed with `/target: no such file or directory` because the default `.dockerignore` excludes `target/` — correct for the self-contained `Dockerfile`, but it hid the prebuilt JAR from `Dockerfile.runtime`.

Adds `Dockerfile.runtime.dockerignore` (BuildKit uses the per-Dockerfile ignore file in preference to `.dockerignore`) that sends only `target/` as the build context.

Verified locally: `docker build -f Dockerfile.runtime` succeeds and emits a multi-arch manifest list.

Merging cuts `v1.6.2` and publishes the multi-arch (`amd64` + `arm64`) image + `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)