### PR TITLE
feat: show app version in page footer

### DIFF
--- a/src/main/java/com/bookstore/controller/VersionController.java
+++ b/src/main/java/com/bookstore/controller/VersionController.java
@@ -1,0 +1,34 @@
+package com.bookstore.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Exposes the application's build version (from {@code pom.xml}, injected at build
+ * time via Maven resource filtering of {@code application.yml}). Public endpoint so
+ * the SPA footer can display it for anonymous visitors too.
+ */
+@RestController
+@RequestMapping("/api/version")
+public class VersionController {
+
+    private final String version;
+
+    public VersionController(@Value("${app.version:dev}") String version) {
+        this.version = version;
+    }
+
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> getVersion() {
+        Map<String, Object> body = new HashMap<>();
+        body.put("version", version);
+        return ResponseEntity.ok(body);
+    }
+
+}

--- a/src/main/java/com/bookstore/security/SecurityConfig.java
+++ b/src/main/java/com/bookstore/security/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/books/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/authors/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/version").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/books").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/books/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.DELETE, "/api/books/**").hasRole("ADMIN")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,9 @@ server:
   error:
     include-message: always
 
+app:
+  version: @project.version@
+
 spring:
   application:
     name: bookstore-api

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -131,3 +131,13 @@ td { font-size: 0.9rem; }
 
 /* --- Table footer --- */
 tfoot td { border-top: 2px solid var(--border); border-bottom: none; }
+
+/* --- Page footer --- */
+.footer {
+    text-align: center;
+    padding: 1.5rem 1rem;
+    margin-top: 2rem;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    border-top: 1px solid var(--border);
+}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -27,6 +27,10 @@
 
     <div id="flash" class="flash" style="display:none;"></div>
 
+    <footer class="footer">
+        <span id="app-version"></span>
+    </footer>
+
     <script src="/js/api.js"></script>
     <script src="/js/auth.js"></script>
     <script src="/js/books.js"></script>

--- a/src/main/resources/static/js/api.js
+++ b/src/main/resources/static/js/api.js
@@ -170,6 +170,12 @@ async function apiClearCart() {
     });
 }
 
+// --- Version API ---
+
+async function apiGetVersion() {
+    return apiFetch('/version');
+}
+
 // --- Orders API ---
 
 async function apiCheckout() {

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -51,7 +51,16 @@ function showFlash(message, type) {
 
 // --- Init ---
 
+function loadVersion() {
+    apiGetVersion()
+        .then(function (data) {
+            document.getElementById('app-version').textContent = 'v' + data.version;
+        })
+        .catch(function () { /* footer version is non-critical */ });
+}
+
 document.addEventListener('DOMContentLoaded', function () {
     updateNavBar();
     navigate('books');
+    loadVersion();
 });

--- a/src/test/java/com/bookstore/controller/VersionControllerTest.java
+++ b/src/test/java/com/bookstore/controller/VersionControllerTest.java
@@ -1,0 +1,54 @@
+package com.bookstore.controller;
+
+import com.bookstore.repository.UserRepository;
+import com.bookstore.security.CustomUserDetailsService;
+import com.bookstore.security.JwtAuthFilter;
+import com.bookstore.security.JwtUtil;
+import com.bookstore.security.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = VersionController.class,
+        excludeAutoConfiguration = UserDetailsServiceAutoConfiguration.class,
+        properties = "app.version=9.9.9")
+@Import({SecurityConfig.class, JwtAuthFilter.class})
+@DisplayName("VersionController")
+class VersionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @Nested
+    @DisplayName("GET /api/version")
+    class GetVersion {
+
+        @Test
+        @DisplayName("returns 200 with the build version for an unauthenticated request")
+        void returnsVersionPublicly() throws Exception {
+            mockMvc.perform(get("/api/version"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.version").value("9.9.9"));
+        }
+    }
+}


### PR DESCRIPTION
## What & why

Displays the application version at the bottom of every page, always in sync with the released version — no manual edits. `semantic-release` bumps `pom.xml`; the value flows automatically to the footer on each build.

## How it works

`@project.version@` in `application.yml` (substituted at build time via Spring Boot's built-in resource filtering) → injected into a new public `GET /api/version` endpoint → fetched by the SPA on load and rendered in the footer.

## Changes

- **`application.yml`** — `app.version: @project.version@` (build-time filtered; `:dev` fallback for unfiltered IDE runs)
- **`VersionController.java`** (new) — public `GET /api/version` → `{"version":"1.6.2"}`
- **`SecurityConfig.java`** — `permitAll` for `/api/version` so the footer shows for anonymous visitors too
- **`index.html` / `style.css`** — `<footer>` + styling using existing CSS variables
- **`api.js` / `app.js`** — `apiGetVersion()` + fetch-on-load that fails silently (footer is non-critical)
- **`VersionControllerTest.java`** (new) — `@WebMvcTest` verifying 200 + version for an unauthenticated request

## Testing

- Full suite green: `Tests run: 67, Failures: 0, Errors: 0`
- Verified `target/classes/application.yml` resolves `@project.version@` → `1.6.2`